### PR TITLE
Fix missing slash in team page

### DIFF
--- a/_includes/shortcodes/team.js
+++ b/_includes/shortcodes/team.js
@@ -42,7 +42,7 @@ export default eleventyConfig =>
             }
           </div>
           <div class="filler">   
-            <a href="${data.site.baseUrl}${item.data.tags && item.data.tags.indexOf('guests') >= 0 ? l10n.guests.url : l10n.team.url}/${item.data.key}/"> 
+            <a href="${data.site.baseUrl}/${item.data.tags && item.data.tags.indexOf('guests') >= 0 ? l10n.guests.url : l10n.team.url}/${item.data.key}/"> 
               <img class="team_member" src="${this.url(`/img/${item.data.photoURL}`)}">
             </a>
           </div>


### PR DESCRIPTION
https://camping-speakers.fr/team/ See that page and click one person to reproduce

🔥
🪵













prems