### PR TITLE
modification du thème sombre

### DIFF
--- a/_includes/shortcodes/css-root.js
+++ b/_includes/shortcodes/css-root.js
@@ -38,7 +38,7 @@ export default eleventyConfig =>
       --space-3: .5rem;
       --space-4: 1rem;
       /* Named Properties */
-      --background-color: var(white);
+      --background-color: var(--white);
       --text-color: var(--grayscale-800);
       --gray: var(--grayscale-600);
       --border: 2px dashed var(--gray);

--- a/_includes/shortcodes/css-root.js
+++ b/_includes/shortcodes/css-root.js
@@ -53,8 +53,9 @@ export default eleventyConfig =>
     }
     @media (prefers-color-scheme: dark) {
       :root {
-        --background-color: var(--black);
+        --background-color: var(--grayscale-800);
         --gray: var(--grayscale-400);
-        --text-color: var(--white);
+        --text-color: var(--grayscale-100);
+        --redish: indianred;
       }
     }`)

--- a/_includes/shortcodes/css-root.js
+++ b/_includes/shortcodes/css-root.js
@@ -29,6 +29,7 @@ export default eleventyConfig =>
       --grayscale-200: ${data.colors.grayscale[200].hex};
       --grayscale-400: ${data.colors.grayscale[400].hex};
       --grayscale-600: ${data.colors.grayscale[600].hex};
+      --grayscale-700: #444;
       --grayscale-800: ${data.colors.grayscale[800].hex};
       --white: ${data.colors.grayscale.white.hex};
       --redish: #800000;
@@ -39,6 +40,7 @@ export default eleventyConfig =>
       --space-4: 1rem;
       /* Named Properties */
       --background-color: var(--white);
+      --card-background: var(--white);
       --text-color: var(--grayscale-800);
       --gray: var(--grayscale-600);
       --border: 2px dashed var(--gray);
@@ -57,5 +59,6 @@ export default eleventyConfig =>
         --gray: var(--grayscale-400);
         --text-color: var(--grayscale-100);
         --redish: indianred;
+        --card-background: var(--grayscale-700);
       }
     }`)

--- a/css/index.css
+++ b/css/index.css
@@ -331,6 +331,7 @@ article.card {
   border-radius: 5px;
   padding: 10px;
   box-shadow: 3px 3px 5px 1px rgba(0, 0, 0, .4);
+  background-color: var(--card-background);
 }
 
 article.card > .card_content {


### PR DESCRIPTION
J'ai repéré 2 légers soucis sur le thème sombre, sur les pages des speakers : 

- Le logo GitHub est peu visible (noir sur noir)
- Les liens sont difficiles à lire (rouge sombre sur noir)

Je propose des changements pour résoudre ces 2 problèmes : 

- thème sombre :
   - fond gris foncé
   - texte gris très clair (but : éviter la fatigue des yeux en proposant un contraste un peu moins élevé que noir/blanc)
   - couleur du lien : indianred
   - page "sponsor" : éclaircissement du fond des cartes des sponsors
- thème clair : aucun changement