### PR TITLE
bugfix : liste des séances d'un speaker

### DIFF
--- a/_includes/layouts/speakers/single.11ty.js
+++ b/_includes/layouts/speakers/single.11ty.js
@@ -51,7 +51,7 @@
                     ${session.data.title}
                 </a>
             </li>`
-            })}
+            }).join("")}
         </ul>
       </article>  
       `;


### PR DESCRIPTION
Quand un speaker avait plusieurs sessions ([exemple : Valériane Venance](https://camping-speakers.fr/speakers/valeriane_venance/)), une virgule mal placée s'affichait en plein milieu de la liste.

Avant le fix : 
![image](https://user-images.githubusercontent.com/20946333/167605423-7c6143ce-8ed4-40dc-8437-0723238e83bf.png)

Après le fix :
![image](https://user-images.githubusercontent.com/20946333/167605463-a656211b-529d-4dde-8679-d14e476fd81d.png)
