### PR TITLE
Minor fixes : links

### DIFF
--- a/_includes/layouts/home.11ty.js
+++ b/_includes/layouts/home.11ty.js
@@ -40,7 +40,7 @@ export function render(data) {
 
     <p></p>
     <h2>Vous hésitez ! Découvrez le programme !</h2>
-    <a href="https://camping-speakers.fr/sessions/" class="button">Le programme</a>
+    <a href="${data.site[data.locale].sessions.url}" class="button">Le programme</a>
     </div>
 
 

--- a/_includes/shortcodes/site-header.js
+++ b/_includes/shortcodes/site-header.js
@@ -29,7 +29,7 @@ export default eleventyConfig =>
     <header>
       <div class="top-content">
         <div class="logo">
-          <a href="${data.site.baseUrl}">
+          <a href="${data.site.pathPrefix}">
             <img src="${data.site.pathPrefix}/${data.site.logo.url}" alt="logo">
           </a>
         </div>


### PR DESCRIPTION
J'ai constaté le comportement suivant : 
- sur toutes les pages du site, le lien du logo pointe vers la prod
- sur la homepage, le lien vers `/sessions` est en dur

J'ai modifiés ces liens pour qu'ils pointent vers les pages correspondantes sur l'environnement de déploiement. 
But : faciliter les tests quand on déploie une version locale (ou gitpod) du site.

Exemple : sur la homepage, le lien `https://camping-speakers.fr/sessions/` devient `{url de mon instance}/sessions/`