### PR TITLE
css : cartes sponsors : border radius + grand

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -328,7 +328,7 @@ article.card {
   width: min(calc(300px - 20px - 4px), 100%);
   height: calc(300px - 20px - 4px);
   border: 0px;
-  border-radius: 5px;
+  border-radius: 15px;
   padding: 10px;
   box-shadow: 3px 3px 5px 1px rgba(0, 0, 0, .4);
 }


### PR DESCRIPTION
J'ai agrandi le rayon des coins des cartes sponsors parce que je trouvais ça plus joli.
C'est totalement objectif : je vous propose le changement, mais je serai satisfait quelle que soit la décision (merge ou rejet) 👍 
Bordure actuelle : 

![image](https://user-images.githubusercontent.com/20946333/167653535-ca270fe0-d96e-4fef-be6e-c80c3200d2d9.png)
nouvelle bordure : 

![image](https://user-images.githubusercontent.com/20946333/167653606-d8d64438-137c-4063-bda3-257e26250687.png)
