### PR TITLE
fix : speaker : entreprise = undefined #27

### DIFF
--- a/_includes/layouts/speakers/single.11ty.js
+++ b/_includes/layouts/speakers/single.11ty.js
@@ -28,7 +28,7 @@
         </div>
         <div class="person_data">
           <h1>${data.name}</h1>
-          <h2>${data.company}</h2>
+          ${typeof data.company == "string" ? `<h2>${data.company}</h2>` : ``}
         </div>
         <div class="content">
           ${data.content}


### PR DESCRIPTION
Quand l'entreprise est vide, ça affiche "undefined" sur la page du speaker.
Ce commit répare ce comportement

Correctif de l'issue #27 