### PR TITLE
fix issue - Logo : lien incorrect #34

### DIFF
--- a/_includes/shortcodes/site-header.js
+++ b/_includes/shortcodes/site-header.js
@@ -29,7 +29,7 @@ export default eleventyConfig =>
     <header>
       <div class="top-content">
         <div class="logo">
-          <a href="${data.site.pathPrefix}">
+          <a href="${data.site.pathPrefix}/">
             <img src="${data.site.pathPrefix}/${data.site.logo.url}" alt="logo">
           </a>
         </div>


### PR DESCRIPTION
Correctif pour l'issue #34 

J'avais modifié le lien du logo (en haut à gauche du site) pour que l'URL ne soit pas en dur.
Ca a introduit un bug : le lien ne redirigeait plus vers la homepage, mais vers la page sur laquelle était déjà le visiteur.

J'ai corrigé ça -> ça redirige bien vers la homepage.