### PR TITLE
feat: display day on session description + minifix

### DIFF
--- a/_includes/layouts/sessions/list.11ty.js
+++ b/_includes/layouts/sessions/list.11ty.js
@@ -101,7 +101,7 @@ function sessionGrid(data, sessions) {
       </header>
       ${data.content}
 
-      ${sessionsByDay(data, data.pagination.items).map((day)=> sessionGrid(data, day))}
+      ${sessionsByDay(data, data.pagination.items).map((day)=> sessionGrid(data, day)).join('')}
 
       <footer>
         ${this.paginationNav(data)}

--- a/_includes/layouts/sessions/single.11ty.js
+++ b/_includes/layouts/sessions/single.11ty.js
@@ -39,11 +39,12 @@ function speakerNameAndPic(data, speaker){
    * @see {@link https://www.11ty.dev/docs/pagination/ Pagination in 11ty}
    */
   export function render(data) {
+    const day = data.day == 0 ? "Jeudi" : "Vendredi";
     return `    
     <article class="session_details">
       <h2>${data.title}</h2>      
       <div>
-        <div class="when">${data.time} - ${data.duration}</div>
+        <div class="when">${day} - ${data.time} - ${data.duration}</div>
         <div class="where">${data.site[data.locale].rooms[data.room].name}</div>
       </div>
 


### PR DESCRIPTION
# Feature
When reading the description of a session (such as {site}/sessions/webassembly_pas_que_frontend/), the visitor can now read the day (Thursday/Friday) alongisde the time and duration.

## Before
![image](https://user-images.githubusercontent.com/20946333/171687415-a1df5aea-cb7e-4058-984b-20186a185de1.png)

## After
![image](https://user-images.githubusercontent.com/20946333/171687434-6fe55702-1ea3-47e0-8a90-7295ddd6ff96.png)

## Note
The list of all the sessions remains unaffected by these modifications:
![image](https://user-images.githubusercontent.com/20946333/171687519-d01e8b76-99e0-4d39-bbc7-d3b4601de016.png)

# Minifix
fix: removed a misplaced comma.

On the page that lists all the sessions, a comma was displayed before "vendredi"
![image](https://user-images.githubusercontent.com/20946333/171688188-c129a231-23da-4c9c-82e2-835319f82210.png)

